### PR TITLE
feature: open on drag up

### DIFF
--- a/notchplus.xcodeproj/project.pbxproj
+++ b/notchplus.xcodeproj/project.pbxproj
@@ -326,10 +326,10 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = notchplus/notchplus.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 0.4;
+				CURRENT_PROJECT_VERSION = 0.4.1;
 				DEVELOPMENT_ASSET_PATHS = "\"notchplus/Preview Content\"";
 				DEVELOPMENT_TEAM = SQ2JHD7BTB;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -344,10 +344,10 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.4;
+				MARKETING_VERSION = 0.4.1;
 				OTHER_LDFLAGS = "$(inherited)";
 				"OTHER_LDFLAGS[arch=*]" = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.notchup;
+				PRODUCT_BUNDLE_IDENTIFIER = com.notchplus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "notchplus/objc/notchplus-Bridging-Header.h";
@@ -369,10 +369,10 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = notchplus/notchplus.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 0.4;
+				CURRENT_PROJECT_VERSION = 0.4.1;
 				DEVELOPMENT_ASSET_PATHS = "\"notchplus/Preview Content\"";
 				DEVELOPMENT_TEAM = SQ2JHD7BTB;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -387,9 +387,9 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.4;
+				MARKETING_VERSION = 0.4.1;
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.notchup;
+				PRODUCT_BUNDLE_IDENTIFIER = com.notchplus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "notchplus/objc/notchplus-Bridging-Header.h";

--- a/notchplus/components/Notch/NotchLayout.swift
+++ b/notchplus/components/Notch/NotchLayout.swift
@@ -17,7 +17,7 @@ struct NotchLayout: View {
     @Binding var gestureProgress: CGFloat
     
     @Namespace var albumArtNamespace
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading) {

--- a/notchplus/models/NotchViewModel.swift
+++ b/notchplus/models/NotchViewModel.swift
@@ -54,6 +54,8 @@ class NotchViewModel: NSObject, ObservableObject {
         cancellables.removeAll()
     }
     
+    var dragObserver: DragObserver?
+    
     override init() {
         self.animation = animationLibrary.animation
         self.notifier = TheBoringWorkerNotifier()
@@ -61,6 +63,8 @@ class NotchViewModel: NSObject, ObservableObject {
         super.init()
         // FIRST LAUNCH ANIMATION TAG
         self.firstLaunch = true
+        self.dragObserver = DragObserver(viewModel: self)
+        self.dragObserver?.startMonitoring()
         
         Publishers.CombineLatest($dropZoneTargeting, $dragDetectorTargetting)
             .map { value1, value2 in

--- a/notchplus/notchplus.entitlements
+++ b/notchplus/notchplus.entitlements
@@ -4,16 +4,18 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.files.downloads.read-only</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-    <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
-    <array>
-        <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
-        <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
-    </array>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+	</array>
 </dict>
 </plist>

--- a/notchplus/observers/DragObserver.swift
+++ b/notchplus/observers/DragObserver.swift
@@ -1,0 +1,63 @@
+//
+//  DragObserver.swift
+//  notchplus
+//
+//  Created by Eduardo Monteiro on 28/11/24.
+//
+
+import SwiftUI
+import Cocoa
+
+class DragObserver {
+    private var monitoring: Bool = false
+    private var lastChangeCount: Int = 0
+    private var lastMousePosition: NSPoint?
+    private var viewModel: NotchViewModel
+    
+    init(viewModel: NotchViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    func startMonitoring() {
+        guard !monitoring else { return }
+        monitoring = true
+        
+        let pasteboard = NSPasteboard(name: .drag)
+        lastChangeCount = pasteboard.changeCount
+        
+        NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDragged) { [weak self] event in
+            self?.checkPasteboard(pasteboard, event: event)
+        }
+        
+        NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { event in
+            print("Drag ended.")
+            self.viewModel.close()
+        }
+    }
+    
+    private func checkPasteboard(_ pasteboard: NSPasteboard, event: NSEvent) {
+        let changeCount = pasteboard.changeCount
+        
+        if lastChangeCount != changeCount {
+            if let lastPosition = lastMousePosition {
+                let currentPosition = event.locationInWindow
+                if currentPosition.y > lastPosition.y {
+                    // only files are accepted
+                    if pasteboard.canReadObject(forClasses: [NSURL.self], options: nil) {
+                        print("Drag started.")
+                        self.viewModel.open()
+                    }
+                    
+                    lastChangeCount = changeCount
+                    lastMousePosition = currentPosition
+                }
+            } else {
+                lastMousePosition = event.locationInWindow
+            }
+        }
+    }
+    
+    func stopMonitoring() {
+        monitoring = false
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the `notchplus` project, primarily focusing on version updates, code signing modifications, and the addition of a new `DragObserver` class. The most important changes are summarized below:

### New Feature - Drag Observer:
* The notch view now opens when dragging a file its direction.
* Added a new `DragObserver` class in `notchplus/observers/DragObserver.swift` to monitor drag events and interact with `NotchViewModel`.
* Integrated `DragObserver` into `NotchViewModel` in `notchplus/models/NotchViewModel.swift`.

### Version and Identifier Updates:
* Updated `CURRENT_PROJECT_VERSION` and `MARKETING_VERSION` to 0.4.1 in `notchplus.xcodeproj/project.pbxproj`. [[1]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L329-R332) [[2]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L347-R350) [[3]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L372-R375) [[4]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L390-R392)
* Changed `PRODUCT_BUNDLE_IDENTIFIER` from `com.notchup` to `com.notchplus` in `notchplus.xcodeproj/project.pbxproj`. [[1]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L347-R350) [[2]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L390-R392)

### Code Signing:
* Modified `CODE_SIGN_IDENTITY` to `"-"` for macOS SDK in `notchplus.xcodeproj/project.pbxproj`. [[1]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L329-R332) [[2]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L372-R375)

### Entitlements:
* Added new entitlements for read-only access to the Downloads folder in `notchplus/notchplus.entitlements`.