### PR TITLE
update timeString to support hours if happens

### DIFF
--- a/notchplus/components/Music/MusicSliderView.swift
+++ b/notchplus/components/Music/MusicSliderView.swift
@@ -43,8 +43,19 @@ struct MusicSliderView: View {
     }
     
     func timeString(from seconds: Double) -> String {
-        let minutes = Int(seconds / 60)
-        let seconds = Int(seconds) % 60
-        return String(format: "%d:%02d", minutes, seconds)
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = .pad
+        
+        if seconds.isNaN {
+            return "0:00"
+        } else if seconds >= 3600 {
+            formatter.allowedUnits = [.hour, .minute, .second]
+            return formatter.string(from: seconds) ?? "0:00"
+        
+        } else {
+            formatter.allowedUnits = [.minute, .second]
+            return formatter.string(from: seconds) ?? "0:00"
+        }
     }
 }


### PR DESCRIPTION
Pull request by issue #5

This pull request includes an update to the `MusicSliderView` component. The primary change involves improving the `timeString(from:)` function to handle different time formats more robustly and to account for edge cases such as NaN values.

Improvements to time formatting:

* [`notchplus/components/Music/MusicSliderView.swift`](diffhunk://#diff-ccc60a0d4d002cf1241c34f7b0bad2535770285de6021b47615c61adbd3dda6fL46-R59): Updated the `timeString(from:)` function to use `DateComponentsFormatter` for more accurate and flexible time formatting. The function now handles NaN values and formats times over an hour correctly. 