### PR TITLE
[FIX] Load File

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -3,12 +3,12 @@
     <channel>
         <title>notchplus</title>
         <item>
-            <title>0.4.1</title>
-            <pubDate>Fri, 29 Nov 2024 23:02:37 -0300</pubDate>
-            <sparkle:version>0.4.1</sparkle:version>
-            <sparkle:shortVersionString>0.4.1</sparkle:shortVersionString>
+            <title>0.4.2</title>
+            <pubDate>Wed, 11 Dec 2024 16:11:12 -0300</pubDate>
+            <sparkle:version>0.4.2</sparkle:version>
+            <sparkle:shortVersionString>0.4.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/notchUP-app/notchup/releases/download/open-on-drag/notchplus.dmg" length="6570147" type="application/octet-stream" sparkle:edSignature="3Ns2fVMqaLRMnKw9RHePz26aDrwywyMMiE1eL/AcQvB/LrknNQrE9GTcTs2QE2zebF12FwpuFEYGyT43fMZqCA=="/>
+            <enclosure url="https://github.com/notchUP-app/notchup/releases/download/fix-file-drop/notchplus.dmg" length="6584349" type="application/octet-stream" sparkle:edSignature="mvCxFNBOeHQ/gm/5R9qV7VUh1TiY3KcOwZjjbVdP3WyEJnEQg21xhcnjCCunDHuqF+hNZroACwa0j7NT3Db8DA=="/>
         </item>
     </channel>
 </rss>

--- a/notchplus.xcodeproj/project.pbxproj
+++ b/notchplus.xcodeproj/project.pbxproj
@@ -329,7 +329,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 0.4.1;
+				CURRENT_PROJECT_VERSION = 0.4.2;
 				DEVELOPMENT_ASSET_PATHS = "\"notchplus/Preview Content\"";
 				DEVELOPMENT_TEAM = SQ2JHD7BTB;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -344,7 +344,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.4.1;
+				MARKETING_VERSION = 0.4.2;
 				OTHER_LDFLAGS = "$(inherited)";
 				"OTHER_LDFLAGS[arch=*]" = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.notchplus;
@@ -372,7 +372,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 0.4.1;
+				CURRENT_PROJECT_VERSION = 0.4.2;
 				DEVELOPMENT_ASSET_PATHS = "\"notchplus/Preview Content\"";
 				DEVELOPMENT_TEAM = SQ2JHD7BTB;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -387,7 +387,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.4.1;
+				MARKETING_VERSION = 0.4.2;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.notchplus;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/notchplus/ContentView.swift
+++ b/notchplus/ContentView.swift
@@ -233,7 +233,10 @@ struct ContentView: View {
                     }
                     
                     viewModel.dropEvent = false
-                    viewModel.close()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        print("Closing")
+                        viewModel.close()
+                    }
                 }
             }
         

--- a/notchplus/notchplus.entitlements
+++ b/notchplus/notchplus.entitlements
@@ -4,12 +4,6 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.assets.movies.read-only</key>
-	<true/>
-	<key>com.apple.security.assets.music.read-only</key>
-	<true/>
-	<key>com.apple.security.assets.pictures.read-only</key>
-	<true/>
 	<key>com.apple.security.files.downloads.read-only</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>

--- a/notchplus/observers/DragObserver.swift
+++ b/notchplus/observers/DragObserver.swift
@@ -32,8 +32,10 @@ class DragObserver {
         }
         
         NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
-            self?.viewModel.close()
-            self?.resetPasteboardChangeCount(pasteboard)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
+                self?.viewModel.close()
+                self?.resetPasteboardChangeCount(pasteboard)
+            }
         }
     }
     
@@ -44,13 +46,9 @@ class DragObserver {
                 let movement = currentPosition.y - lastPosition.y
                 
                 if movement > upwardMovementThreshold {
-                    if isFileDrag(pasteboard) {
-                        self.viewModel.open()
-                    }
+                    self.viewModel.open()
                 } else if movement < downwardMovementThreshold {
-                    if isFileDrag(pasteboard) {
-                        self.viewModel.close()
-                    }
+                    self.viewModel.close()
                 }
                 
                 lastMousePosition = currentPosition
@@ -58,20 +56,6 @@ class DragObserver {
                 lastMousePosition = event.locationInWindow
             }
         }
-    }
-    
-    private func isFileDrag(_ pasteboard: NSPasteboard) -> Bool {
-        if let types = pasteboard.types, types.contains(.fileURL) {
-            if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL], urls.count > 0 {
-                for url in urls {
-                    if url.isFileURL {
-                        return true
-                    }
-                }
-            }
-        }
-        
-        return false
     }
     
     private func resetPasteboardChangeCount(_ pasteboard: NSPasteboard) {


### PR DESCRIPTION
This pull request includes several changes to update the version number, improve the drag-and-drop functionality, and clean up entitlements. The most important changes include updating the version number in multiple files, adding delays to asynchronous operations, and removing unnecessary entitlements and methods.

Version updates:
* [`appcast.xml`](diffhunk://#diff-a83b2ea9fe264ad87bb237369388273b0ef302202bb1f3e678012edfe85aa4aeL6-R11): Updated version number from 0.4.1 to 0.4.2 and changed the enclosure URL and file length.
* [`notchplus.xcodeproj/project.pbxproj`](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L332-R332): Updated `CURRENT_PROJECT_VERSION` and `MARKETING_VERSION` from 0.4.1 to 0.4.2 in multiple places. [[1]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L332-R332) [[2]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L347-R347) [[3]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L375-R375) [[4]](diffhunk://#diff-74d994cea9b2a4e3b84e230f14d0a375218c2a680014a460be0bba5ca34c92e3L390-R390)

Asynchronous operations:
* [`notchplus/ContentView.swift`](diffhunk://#diff-ef28664cc259a146d0dbad7700c5a9451852a552fd09e24e637c90275c23a77eR236-R241): Added a delay before closing the view model in the `dropEvent` handler.
* [`notchplus/observers/DragObserver.swift`](diffhunk://#diff-1ebeca6b16933df1b9bddd97704a26ae7c6807b49b3fad4962914dcb11837857R35-R40): Added a delay before closing the view model in the global monitor for leftMouseUp events.

Code cleanup:
* [`notchplus/notchplus.entitlements`](diffhunk://#diff-c0b04aa290ec58db0d34940fecd86841176643ca5bea81500a6c6ab81981203aL7-L12): Removed unnecessary entitlements related to read-only access to movies, music, and pictures.
* [`notchplus/observers/DragObserver.swift`](diffhunk://#diff-1ebeca6b16933df1b9bddd97704a26ae7c6807b49b3fad4962914dcb11837857L47-L54): Removed the `isFileDrag` method and its usage. [[1]](diffhunk://#diff-1ebeca6b16933df1b9bddd97704a26ae7c6807b49b3fad4962914dcb11837857L47-L54) [[2]](diffhunk://#diff-1ebeca6b16933df1b9bddd97704a26ae7c6807b49b3fad4962914dcb11837857L63-L76)