### PR TITLE
Feature/lockscreen

### DIFF
--- a/notchplus/AppDelegate.swift
+++ b/notchplus/AppDelegate.swift
@@ -6,13 +6,18 @@
 //
 
 import SwiftUI
+import Defaults
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     @ObservedObject var coordinator = NotchViewCoordinator.shared
     
     var viewModel: NotchViewModel = NotchViewModel.shared
+    var viewModels: [NSScreen: NotchViewModel] = [:]
     
-    var window: NotchUpWindow!
+    var window: NSWindow!
+    var windows: [NSScreen: NSWindow] = [:]
+    private var previousScreen: [NSScreen]?
+    
     var animationWindow: NSWindow?
     let sizing: Sizes = .init()
     private var previousScreens: [NSScreen]?
@@ -20,50 +25,131 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         NotificationCenter.default.removeObserver(self)
     }
+    
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        return false
+    }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApplication.shared.setActivationPolicy(.accessory)
-
+        
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(adjustWindowPosition),
+            selector: #selector(screenConfigurationDidChange),
             name: NSApplication.didChangeScreenParametersNotification,
             object: nil
         )
-
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name.selectedScreenChanged, object: nil, queue: nil
-        ) { [weak self] _ in
-            self?.adjustWindowPosition()
+    
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(onScreenLocked(_:)),
+            name: NSNotification.Name(rawValue: "com.apple.screenIsLocked"),
+            object: nil
+        )
+        
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(onScreenUnlocked(_:)),
+            name: NSNotification.Name(rawValue: "com.apple.screenIsUnlocked"),
+            object: nil
+        )
+        
+        if coordinator.firstLaunch {
+            DispatchQueue.main.async {
+                self.showAnimationOverlay()
+            }
+        } else {
+            createAndShowMainWindow()
         }
-
-        adjustWindowPosition()
-
-        showAnimationOverlay()
+        
+        
     }
 
-    @objc func adjustWindowPosition() {
-        guard let window = window else { return }
-
-        if !NSScreen.screens.contains(where: { $0.localizedName == coordinator.selectedScreen }) {
-            viewModel.coordinator.selectedScreen = NSScreen.main?.localizedName ?? "Unknown Screen"
-        }
-
-        let selectedScreen = NSScreen.screens.first(where: {
-            $0.localizedName == coordinator.selectedScreen
-        })
-        closedNotchSize = setNotchSize(screen: selectedScreen?.localizedName)
-
-        if let screenFrame = selectedScreen {
-            DispatchQueue.main.async {
-                let origin = screenFrame.frame.origin.applying(
-                    CGAffineTransform(
-                        translationX: (screenFrame.frame.width / 2) - window.frame.width / 2,
-                        y: screenFrame.frame.height - window.frame.height
+    @objc func adjustWindowPosition(changeAlpha: Bool = false) {
+        if Defaults[.showOnAllDisplays] {
+            for screen in NSScreen.screens {
+                if windows[screen] == nil {
+                    let viewModel: NotchViewModel = .init(screen: screen.localizedName)
+                    let window = NotchUpWindow(
+                        contentRect: NSRect(
+                            x: 0, y: 0, width: sizing.size.opened.width! + 20, height: sizing.size.opened.height! + 30
+                        ),
+                        styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
+                        backing: .buffered,
+                        defer: false
                     )
-                )
+                    
+                    window.contentView = NSHostingView(
+                        rootView: ContentView(
+                            onHover: adjustWindowPosition,
+                            coordinator: NotchViewCoordinator.shared,
+                            viewModel: viewModel,
+                            batteryModel: .init(viewModel: viewModel)
+                        )
+                        .environmentObject(viewModel)
+                        .environmentObject(MusicManager(viewModel: viewModel)!)
+                    )
+                    
+                    windows[screen] = window
+                    viewModels[screen] = viewModel
+                    window.orderFrontRegardless()
+                    
+                }
+                
+                if let window = windows[screen] {
+                    window.alphaValue = changeAlpha ? 0 : 1
+                    
+                    DispatchQueue.main.async {
+                        let screenFrame = screen.frame
+                        window.setFrameOrigin(
+                            NSPoint(
+                                x: screenFrame.origin.x + (screenFrame.width / 2) - window.frame.width / 2,
+                                y: screenFrame.origin.y + screenFrame.height - window.frame.height
+                            )
+                        )
+                        
+                        window.alphaValue = 1
+                    }
+                }
+                
+                if let viewModel = viewModels[screen] {
+                    if viewModel.notchState == .closed {
+                        viewModel.close()
+                    }
+                }
+            }
+        }
+        else {
+            if !NSScreen.screens.contains(where: { $0.localizedName == coordinator.selectedScreen }) {
+                coordinator.selectedScreen = NSScreen.main?.localizedName ?? "Unknown"
+            }
 
-                window.setFrameOrigin(origin)
+            let selectedScreen = NSScreen.screens.first(where: {
+                $0.localizedName == coordinator.selectedScreen
+            })
+            closedNotchSize = setNotchSize(screen: selectedScreen?.localizedName)
+
+            if let screenFrame = selectedScreen {
+                window.alphaValue = changeAlpha ? 0 : 1
+                window.makeKeyAndOrderFront(nil)
+                
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    
+                    let origin = screenFrame.frame.origin.applying(
+                        CGAffineTransform(
+                            translationX: (screenFrame.frame.width / 2) - window.frame.width / 2,
+                            y: screenFrame.frame.height - window.frame.height
+                        )
+                    )
+
+                    window.setFrameOrigin(origin)
+                    window.alphaValue = 1
+                }
+            }
+            
+            if viewModel.notchState == .closed {
+                viewModel.close()
             }
         }
     }
@@ -93,33 +179,138 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         animationWindow?.makeKeyAndOrderFront(nil)
     }
-
+    
+    private func cleanupWindows() {
+        if Defaults[.showOnAllDisplays] {
+            for window in windows.values {
+                window.close()
+                SpaceManager.shared.space.windows.remove(window)
+            }
+            
+            windows.removeAll()
+            viewModels.removeAll()
+        }
+        else if let window = window {
+            window.close()
+            SpaceManager.shared.space.windows.remove(window)
+        }
+    }
+    
+    @objc func onScreenLocked(_ : Notification) {
+        Logger.log("Screen locked", type: .debug)
+        cleanupWindows()
+    }
+    
+    @objc func onScreenUnlocked(_ : Notification) {
+        Logger.log("Screen unlocked", type: .debug)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            self?.cleanupWindows()
+//            self?.showAnimationOverlay()
+            self?.adjustWindowPosition()
+        }
+    }
+    
+    @objc func screenConfigurationDidChange() {
+        let currentScreens = NSScreen.screens
+        let screensChanged = currentScreens.count != previousScreens?.count ||
+        Set(currentScreens.map { $0.localizedName }) != Set(previousScreens?.map { $0.localizedName } ?? [])
+        
+        if screensChanged {
+            Logger.log("Screens changed", type: .debug)
+            
+            previousScreens = currentScreens
+            cleanupWindows()
+            adjustWindowPosition()
+        }
+    }
+    
     private func createAndShowMainWindow() {
-        self.window = NotchUpWindow(
-            contentRect: NSRect(
-                x: 0, y: 0, width: sizing.size.opened.width! + 20,
-                height: sizing.size.opened.height! + 30),
-            styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
-            backing: .buffered,
-            defer: false
-        )
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name.selectedScreenChanged,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.adjustWindowPosition(changeAlpha: true)
+        }
         
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name.notchHeightChanged,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.adjustWindowPosition()
+        }
         
-
-        self.window?.contentView = NSHostingView(
-            rootView: ContentView(
-                onHover: adjustWindowPosition,
-                coordinator: NotchViewCoordinator.shared,
-                viewModel: viewModel,
-                batteryModel: .init(viewModel: self.viewModel)
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name.showOnAllDisplaysChanged,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            if (!Defaults[.showOnAllDisplays]) {
+                self?.window = NotchUpWindow(
+                    contentRect: NSRect(x: 0, y: 0, width: Sizes.shared.size.opened.width!, height: Sizes.shared.size.opened.height!),
+                    styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
+                    backing: .buffered,
+                    defer: false
+                )
+                
+                if let windowValues = self?.windows.values {
+                    for window in windowValues {
+                        window.close()
+                    }
+                }
+                
+                self?.window.contentView = NSHostingView(
+                    rootView: ContentView(
+                        onHover: self!.adjustWindowPosition,
+                        coordinator: NotchViewCoordinator.shared,
+                        viewModel: self!.viewModel,
+                        batteryModel: .init(viewModel: self!.viewModel)
+                    )
+                    .environmentObject(self!.viewModel)
+                    .environmentObject(MusicManager(viewModel: self!.viewModel)!)
+                )
+                
+                self?.adjustWindowPosition(changeAlpha: true)
+                
+                self?.window.orderFrontRegardless()
+                
+                SpaceManager.shared.space.windows.insert(self!.window)
+            }
+            else {
+                self?.window.close()
+                self?.windows = [:]
+                self?.adjustWindowPosition()
+            }
+        }
+        
+        if !Defaults[.showOnAllDisplays] {
+            window = NotchUpWindow(
+                contentRect: NSRect(x: 0, y: 0, width: Sizes.shared.size.opened.width!, height: Sizes.shared.size.opened.height!),
+                styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
+                backing: .buffered,
+                defer: false
             )
-            .environmentObject(viewModel)
-            .environmentObject(MusicManager(viewModel: viewModel)!)
-        )
-
-        adjustWindowPosition()
-
-        self.window?.alphaValue = 1
-        self.window?.makeKeyAndOrderFront(nil)
+            
+            window.contentView = NSHostingView(
+                rootView: ContentView(
+                    onHover: adjustWindowPosition,
+                    coordinator: NotchViewCoordinator.shared,
+                    viewModel: viewModel,
+                    batteryModel: .init(viewModel: viewModel)
+                )
+                .environmentObject(viewModel)
+                .environmentObject(MusicManager(viewModel: viewModel)!)
+            )
+            
+            adjustWindowPosition(changeAlpha: true)
+            
+            window.orderFrontRegardless()
+            
+            SpaceManager.shared.space.windows.insert(window)
+        } else {
+            adjustWindowPosition()
+        }
     }
 }

--- a/notchplus/ContentView.swift
+++ b/notchplus/ContentView.swift
@@ -187,7 +187,7 @@ struct ContentView: View {
                 // change to `DispatchQueue.main.async { ... }` to make it start on open
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     withAnimation(viewModel.animation) {
-                        if viewModel.firstLaunch {
+                        if coordinator.firstLaunch {
                             doOpen()
                         }
                     }

--- a/notchplus/ContentView.swift
+++ b/notchplus/ContentView.swift
@@ -9,7 +9,7 @@ import Defaults
 import SwiftUI
 
 struct ContentView: View {
-    let onHover: () -> Void
+    let onHover: (Bool) -> Void
     
     @ObservedObject var coordinator: NotchViewCoordinator
     @ObservedObject var viewModel: NotchViewModel
@@ -29,7 +29,7 @@ struct ContentView: View {
     @AppStorage("firstLaunch") private var firstLaunch: Bool = false
     
     init (
-        onHover: @escaping () -> Void,
+        onHover: @escaping (Bool) -> Void,
         coordinator: NotchViewCoordinator = .shared,
         viewModel: NotchViewModel,
         batteryModel: BatteryStatusViewModel

--- a/notchplus/common/Sizes.swift
+++ b/notchplus/common/Sizes.swift
@@ -51,6 +51,8 @@ func setNotchSize(screen: String? = nil) -> CGSize {
 }
 
 struct Sizes {
+    static let shared = Sizes()
+    
     var cornerRadius: NotchSizeState = NotchSizeState(opened: Area(inset: 24), closed: Area(inset: 10))
     var size: NotchSizeState = NotchSizeState(
         opened: Area(width: 580, height: 175),

--- a/notchplus/components/Notch/NotchHomeView.swift
+++ b/notchplus/components/Notch/NotchHomeView.swift
@@ -13,6 +13,7 @@ struct NotchHomeView: View {
     @EnvironmentObject var viewModel: NotchViewModel
     @EnvironmentObject var batteryModel: BatteryStatusViewModel
     @EnvironmentObject var musicManager: MusicManager
+    @ObservedObject var coordinator = NotchViewCoordinator.shared
     
     @State private var sliderValue: Double = 0.0
     @State private var dragging: Bool = false
@@ -22,7 +23,7 @@ struct NotchHomeView: View {
     let albumArtNamespace: Namespace.ID
     
     var body: some View {
-        if !viewModel.firstLaunch {
+        if !coordinator.firstLaunch {
             HStack(alignment: .top, spacing: 10) {
                 ZStack(alignment: .bottomTrailing) {
                     if Defaults[.blurredArtwork] {
@@ -125,7 +126,9 @@ struct NotchHomeView: View {
 
             }
             .onAppear {
-                viewModel.open()
+                if coordinator.firstLaunch {
+                    viewModel.open()
+                }
                 sliderValue = musicManager.elapsedTime
                 startTimer()
             }

--- a/notchplus/components/Notch/NotchLayout.swift
+++ b/notchplus/components/Notch/NotchLayout.swift
@@ -12,6 +12,7 @@ struct NotchLayout: View {
     @EnvironmentObject var viewModel: NotchViewModel
     @EnvironmentObject var musicManager: MusicManager
     @EnvironmentObject var batteryModel: BatteryStatusViewModel
+    @ObservedObject var coordinator = NotchViewCoordinator.shared
     
     @Binding var hoverAnimation: Bool
     @Binding var gestureProgress: CGFloat
@@ -35,13 +36,16 @@ struct NotchLayout: View {
     private func Layout() -> some View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading) {
-                if viewModel.firstLaunch {
+                if coordinator.firstLaunch {
                     Spacer()
                     HelloAnimation()
                         .frame(width: 200, height: 80)
                         .onAppear(perform: {
                             viewModel.closeHello()
                         })
+                        .onDisappear {
+                            coordinator.firstLaunch = false
+                        }
                         .padding(.top, 40)
                     Spacer()
                 }

--- a/notchplus/components/Settings/Sections/GeneralView.swift
+++ b/notchplus/components/Settings/Sections/GeneralView.swift
@@ -14,6 +14,8 @@ struct GeneralView: View {
     @State var screens: [String] = NSScreen.screens.map { $0.localizedName }
     @ObservedObject var coordinator = NotchViewCoordinator.shared
     
+    @Default(.showOnAllDisplays) var showOnAllDisplays
+    
     var body: some View {
         VStack {
             Form {
@@ -28,15 +30,20 @@ struct GeneralView: View {
                 }
                 
                 Section {
-                    Picker("Main display", selection: $coordinator.mainScreenName) {
-                        ForEach(screens, id: \.self) { screen in
-                            Text(screen)
+                    Defaults.Toggle("Show on all dislpays", key: .showOnAllDisplays)
+                        .toggleStyle(SwitchToggleStyle(tint: Defaults[.accentColor]))
+                    
+                    if !showOnAllDisplays {
+                        Picker("Main display", selection: $coordinator.mainScreenName) {
+                            ForEach(screens, id: \.self) { screen in
+                                Text(screen)
+                            }
                         }
+                        .onChange(of: NSScreen.screens) { old, new in
+                            screens = new.compactMap({ $0.localizedName })
+                        }
+                        .pickerStyle(.menu)
                     }
-                    .onChange(of: NSScreen.screens) { old, new in
-                        screens = new.compactMap({ $0.localizedName })
-                    }
-                    .pickerStyle(.menu)
                 } header: {
                     Text("Display")
                         .fontWeight(.semibold)

--- a/notchplus/components/Settings/Sections/GeneralView.swift
+++ b/notchplus/components/Settings/Sections/GeneralView.swift
@@ -32,6 +32,9 @@ struct GeneralView: View {
                 Section {
                     Defaults.Toggle("Show on all dislpays", key: .showOnAllDisplays)
                         .toggleStyle(SwitchToggleStyle(tint: Defaults[.accentColor]))
+                        .onChange(of: showOnAllDisplays) {
+                            NotificationCenter.default.post(name: Notification.Name.showOnAllDisplaysChanged, object: nil)
+                        }
                     
                     if !showOnAllDisplays {
                         Picker("Main display", selection: $coordinator.mainScreenName) {

--- a/notchplus/extensions/Ext+NotificationName.swift
+++ b/notchplus/extensions/Ext+NotificationName.swift
@@ -6,7 +6,12 @@
 //
 
 extension Notification.Name {
-    static let selectedScreenChanged = Notification.Name("SelectedScreenChanged")
+    
     static let musicArtworkChanged = Notification.Name("MusicArtworkChanged")
     static let musicInfoChanged = Notification.Name("MusicInfoChanged")
+    
+    // Screen
+    static let selectedScreenChanged = Notification.Name("SelectedScreenChanged")
+    static let notchHeightChanged = Notification.Name("NotchHeightChanged")
+    static let showOnAllDisplaysChanged = Notification.Name("ShowOnAllDisplaysChanged")
 }

--- a/notchplus/helpers/Ext+Defaults.swift
+++ b/notchplus/helpers/Ext+Defaults.swift
@@ -12,6 +12,7 @@ extension Defaults.Keys {
     // MARK: GENERAL
     static let menuBarIcon = Key<Bool>("menuBarIcon", default: true)
     static let dropBoxByDefault = Key<Bool>("dropBoxByDefault", default: true)
+    static let showOnAllDisplays = Key<Bool>("showOnAllDisplays", default: true)
     
     // MARK: APPEARENCE
     static let matchSystemAccent = Key<Bool>("matchSystemAccent", default: true)

--- a/notchplus/managers/SpaceManager.swift
+++ b/notchplus/managers/SpaceManager.swift
@@ -1,0 +1,18 @@
+//
+//  SpaceManager.swift
+//  notchplus
+//
+//  Created by Eduardo Monteiro on 01/04/25.
+//
+
+import SwiftUI
+
+class SpaceManager {
+    static let shared = SpaceManager()
+    let space: CGSSpace
+    
+
+    private init() {
+        space = CGSSpace(level: 2147483647)
+    }
+}

--- a/notchplus/private/CGSSpace.swift
+++ b/notchplus/private/CGSSpace.swift
@@ -1,0 +1,70 @@
+//
+//  CGSSpace.swift
+//  boringNotch
+//
+//  Created by Alexander Greco on 2024-10-27.
+//
+
+/// Small Spaces API wrapper.
+public final class CGSSpace {
+    private let identifier: CGSSpaceID
+    private let createdByInit: Bool
+
+    public var windows: Set<NSWindow> = [] {
+        didSet {
+            let remove = oldValue.subtracting(self.windows)
+            let add = self.windows.subtracting(oldValue)
+
+            CGSRemoveWindowsFromSpaces(_CGSDefaultConnection(),
+                                       remove.map { $0.windowNumber } as NSArray,
+                                       [self.identifier])
+            CGSAddWindowsToSpaces(_CGSDefaultConnection(),
+                                  add.map { $0.windowNumber } as NSArray,
+                                  [self.identifier])
+        }
+    }
+
+    /// Initialized `CGSSpace`s *MUST* be de-initialized upon app exit!
+    public init(level: Int = 0) {
+        let flag = 0x1 // this value MUST be 1, otherwise, Finder decides to draw desktop icons
+        self.identifier = CGSSpaceCreate(_CGSDefaultConnection(), flag, nil)
+        CGSSpaceSetAbsoluteLevel(_CGSDefaultConnection(), self.identifier, level)
+        CGSShowSpaces(_CGSDefaultConnection(), [self.identifier])
+        self.createdByInit = true // Mark as created by the first init
+    }
+
+    public init(id: UInt64) {
+        let flag = 0x1 // this value MUST be 1, otherwise, Finder decides to draw desktop icons
+        self.identifier = id
+        CGSShowSpaces(_CGSDefaultConnection(), [self.identifier])
+        self.createdByInit = false // Mark as created externally
+    }
+
+    deinit {
+        CGSHideSpaces(_CGSDefaultConnection(), [self.identifier])
+        // Only call CGSSpaceDestroy if the space was created by the first init
+        if createdByInit {
+            CGSSpaceDestroy(_CGSDefaultConnection(), self.identifier)
+        }
+    }
+}
+
+// CGSSpace stuff:
+fileprivate typealias CGSConnectionID = UInt
+fileprivate typealias CGSSpaceID = UInt64
+@_silgen_name("_CGSDefaultConnection")
+fileprivate func _CGSDefaultConnection() -> CGSConnectionID
+@_silgen_name("CGSSpaceCreate")
+fileprivate func CGSSpaceCreate(_ cid: CGSConnectionID, _ unknown: Int, _ options: NSDictionary?) -> CGSSpaceID
+@_silgen_name("CGSSpaceDestroy")
+fileprivate func CGSSpaceDestroy(_ cid: CGSConnectionID, _ space: CGSSpaceID)
+@_silgen_name("CGSSpaceSetAbsoluteLevel")
+fileprivate func CGSSpaceSetAbsoluteLevel(_ cid: CGSConnectionID, _ space: CGSSpaceID, _ level: Int)
+@_silgen_name("CGSAddWindowsToSpaces")
+fileprivate func CGSAddWindowsToSpaces(_ cid: CGSConnectionID, _ windows: NSArray, _ spaces: NSArray)
+@_silgen_name("CGSRemoveWindowsFromSpaces")
+fileprivate func CGSRemoveWindowsFromSpaces(_ cid: CGSConnectionID, _ windows: NSArray, _ spaces: NSArray)
+@_silgen_name("CGSHideSpaces")
+fileprivate func CGSHideSpaces(_ cid: CGSConnectionID, _ spaces: NSArray)
+@_silgen_name("CGSShowSpaces")
+fileprivate func CGSShowSpaces(_ cid: CGSConnectionID, _ spaces: NSArray)

--- a/notchplus/private/CGSSpace.swift
+++ b/notchplus/private/CGSSpace.swift
@@ -1,11 +1,10 @@
 //
 //  CGSSpace.swift
-//  boringNotch
+//  notchplus
 //
-//  Created by Alexander Greco on 2024-10-27.
+//  Created by Eduardo Monteiro on 01/04/25.
 //
 
-/// Small Spaces API wrapper.
 public final class CGSSpace {
     private let identifier: CGSSpaceID
     private let createdByInit: Bool


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and flexibility of the `notchplus` application, particularly focusing on multi-display support, screen locking behavior, and application state management.

### Multi-display support:

* Added support for showing the application on all connected displays with the ability to toggle this feature (`notchplus/AppDelegate.swift`, `notchplus/components/Settings/Sections/GeneralView.swift`, `notchplus/extensions/Ext+NotificationName.swift`, `notchplus/helpers/Ext+Defaults.swift`). [[1]](diffhunk://#diff-6acdc1110b460d477c78a47d2a6514a20aeedeeff370b3086067fd6268614851R9-L15) [[2]](diffhunk://#diff-b0b69ce512af8882658b3e1c5e1ad4ba849a304a992e418e37447c25c7e48487R17-R18) [[3]](diffhunk://#diff-5c1a0b3a78a8d03344ee3a48c7a20948d5337c758c0a48a6176f1ab93c5976deL9-R16) [[4]](diffhunk://#diff-e6c532a74a4fd9eeaf07ba2f8f9dc5db7c9ff8c59431bc9bab33cc2742d56f9bR15)

### Screen locking behavior:

* Implemented functionality to handle screen lock and unlock events, ensuring the application windows are properly cleaned up and recreated (`notchplus/AppDelegate.swift`). [[1]](diffhunk://#diff-6acdc1110b460d477c78a47d2a6514a20aeedeeff370b3086067fd6268614851R29-R124) [[2]](diffhunk://#diff-6acdc1110b460d477c78a47d2a6514a20aeedeeff370b3086067fd6268614851R183-R314)

### Application state management:

* Introduced a `SpaceManager` class to manage application windows and their states (`notchplus/managers/SpaceManager.swift`).
* Modified various components to use a shared `NotchViewCoordinator` for better state management (`notchplus/components/Notch/NotchHomeView.swift`, `notchplus/components/Notch/NotchLayout.swift`). [[1]](diffhunk://#diff-8eede26fdf417af7b7640d5eba1ea136f87ae419600159ba84a140a4319e7479R16) [[2]](diffhunk://#diff-bdd6f6771e404f3331f344350e308db42956ccf9f1e961d8e1e53ce1b4e5f819R15)

### Code improvements:

* Updated `ContentView` to accept a boolean parameter for the `onHover` function and adjusted related logic (`notchplus/ContentView.swift`). [[1]](diffhunk://#diff-ef28664cc259a146d0dbad7700c5a9451852a552fd09e24e637c90275c23a77eL12-R12) [[2]](diffhunk://#diff-ef28664cc259a146d0dbad7700c5a9451852a552fd09e24e637c90275c23a77eL32-R32)
* Added a shared instance of the `Sizes` struct for consistent sizing across the application (`notchplus/common/Sizes.swift`).